### PR TITLE
Build YadifMod2 under linux

### DIFF
--- a/avisynth/build/CMakeLists.txt
+++ b/avisynth/build/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(YadifMod2)
+
+find_path(AVS_FOUND avisynth.h HINTS /usr/include /usr/local/include PATH_SUFFIXES avisynth)
+if (NOT AVS_FOUND)
+    message(FATAL_ERROR "AviSynth+ not found.")
+else()
+    message(STATUS "AviSynth+ : ${AVS_FOUND}")
+endif()
+
+set(CMAKE_CXX_FLAGS " -Wall -Wextra -O3 -fPIC -mavx2 ")
+
+#include_directories("include/")
+
+file(GLOB SOURCES "../src/*.cpp")
+
+add_library(yadifmod2 SHARED ${SOURCES})
+
+# I won't worry about installation ATM
+#install(TARGETS rawsourceplus DESTINATION /usr/local/lib)
+

--- a/avisynth/src/common.h
+++ b/avisynth/src/common.h
@@ -2,6 +2,9 @@
 #define YADIF_MOD2_COMMON_H
 
 #include <cstdint>
+#ifndef _WIN32
+#include <avisynth/avisynth.h>
+#endif
 
 #define __AVX__
 

--- a/avisynth/src/simd.h
+++ b/avisynth/src/simd.h
@@ -30,8 +30,11 @@
 #endif
 #include "common.h"
 
-
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 
 namespace simd {

--- a/avisynth/src/yadifmod2.cpp
+++ b/avisynth/src/yadifmod2.cpp
@@ -29,12 +29,14 @@
 #include <cstdint>
 #include <algorithm>
 #include <stdexcept>
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
 #define NOMINMAX
 #define NOGDI
 #include <windows.h>
 #include <avisynth.h>
+#endif
 
 #include "common.h"
 
@@ -280,7 +282,6 @@ create_yadifmod2(AVSValue args, void* user_data, IScriptEnvironment* env)
         }
 
         arch_t arch = get_arch(args[5].AsInt(-1), env);
-        validate(args[5].AsInt() < 0 || args[5].AsInt() > 4, "opt must be between 0..4.");
 
         return new YadifMod2(child, edeint, order, field, mode, arch, env);
 
@@ -291,7 +292,10 @@ create_yadifmod2(AVSValue args, void* user_data, IScriptEnvironment* env)
 }
 
 
-static const AVS_Linkage* AVS_linkage = nullptr;
+#ifdef _WIN32
+static
+#endif
+const AVS_Linkage* AVS_linkage = nullptr;
 
 
 extern "C" __declspec(dllexport) const char* __stdcall


### PR DESCRIPTION
I applied minor modifications in order to have yadifmod built as native lib on my linux x64 box. It is now running smooth as libyadifmod2.so givin' bit identical deinterlacing result - using any arch.
Please note I removed statement https://github.com/Asd-g/yadifmod2/blob/2c4f2146975eae83fc17749e40c1a02a2a06020d/avisynth/src/yadifmod2.cpp#L283 as a fix mainly because it makes an assertion fail when built with g++ (AsInt called with no parameter). Further, readme says any value is accepted :-)