### PR TITLE
Build under linux

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.1)
+
+set(ProjectName "YadifMod2")
+
+project(${ProjectName} LANGUAGES CXX)
+
+string(TOLOWER "${ProjectName}" LibName)
+
+find_path(AVS_FOUND avisynth.h HINTS /usr/include /usr/local/include PATH_SUFFIXES avisynth)
+if (NOT AVS_FOUND)
+    message(FATAL_ERROR "AviSynth+ not found.")
+else()
+    message(STATUS "AviSynth+ : ${AVS_FOUND}")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -O3 ")
+
+#include_directories("include/")
+
+file(GLOB SOURCES "../src/*.cpp")
+
+# special SSE2 option for source files with *_sse2.cpp pattern
+file(GLOB_RECURSE SRCS_SSE2 "../src/*_sse2.cpp")
+set_source_files_properties(${SRCS_SSE2} PROPERTIES COMPILE_FLAGS " -msse2 ")
+
+# special SSSE3 option for source files with *_ssse3.cpp pattern
+file(GLOB_RECURSE SRCS_SSSE3 "../src/*_ssse3.cpp")
+set_source_files_properties(${SRCS_SSSE3} PROPERTIES COMPILE_FLAGS " -mssse3 ")
+
+# special SSE41 option for source files with *_sse41.cpp pattern
+file(GLOB_RECURSE SRCS_SSE41 "../src/*_sse41.cpp")
+set_source_files_properties(${SRCS_SSE41} PROPERTIES COMPILE_FLAGS " -msse4.1 ")
+
+# special AVX option for source files with *_avx.cpp pattern
+file(GLOB_RECURSE SRCS_AVX "../src/*_avx.cpp")
+set_source_files_properties(${SRCS_AVX} PROPERTIES COMPILE_FLAGS " -mavx ")
+
+# special AVX2 option for source files with *_avx2.cpp pattern
+file(GLOB_RECURSE SRCS_AVX2 "../src/*_avx2.cpp")
+set_source_files_properties(${SRCS_AVX2} PROPERTIES COMPILE_FLAGS " -mavx2 -mfma ")
+
+add_library("${LibName}" SHARED ${SOURCES})
+
+# I won't worry about installation ATM
+#install(TARGETS yadifmod2 DESTINATION /usr/local/lib)
+

--- a/src/common.h
+++ b/src/common.h
@@ -3,7 +3,9 @@
 
 #include <cstdint>
 #include <algorithm>
-
+#ifndef _WIN32
+#include <avisynth/avisynth.h>
+#endif
 
 enum class arch_t {
     NO_SIMD,

--- a/src/proc_filter.cpp
+++ b/src/proc_filter.cpp
@@ -30,7 +30,11 @@
 
 #include "common.h"
 
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 static F_INLINE int average2(const int x, const int y) noexcept
 {

--- a/src/simd.h
+++ b/src/simd.h
@@ -28,7 +28,11 @@
 #include "common.h"
 
 
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 
 namespace simd {

--- a/src/simd_avx.h
+++ b/src/simd_avx.h
@@ -32,7 +32,11 @@
 #endif
 
 
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 
 namespace simd {

--- a/src/simd_avx2.h
+++ b/src/simd_avx2.h
@@ -32,7 +32,11 @@
 #endif
 
 
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 
 namespace simd {

--- a/src/yadifmod2.cpp
+++ b/src/yadifmod2.cpp
@@ -28,8 +28,9 @@
 
 
 #include <stdexcept>
-
+#ifdef _WIN32
 #include "avisynth.h"
+#endif
 #include "common.h"
 
 #define WIN32_LEAN_AND_MEAN
@@ -39,7 +40,11 @@
 
 #define YADIF_MOD_2_VERSION "0.2.6"
 
+#ifndef __GNUC__
 #define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
 
 
 static F_INLINE int average(const int x, const int y) noexcept
@@ -345,8 +350,10 @@ create_yadifmod2(AVSValue args, void* user_data, IScriptEnvironment* env)
     return 0;
 }
 
-
-static const AVS_Linkage* AVS_linkage = nullptr;
+#ifdef _WIN32
+static
+#endif
+const AVS_Linkage* AVS_linkage = nullptr;
 
 
 extern "C" __declspec(dllexport) const char* __stdcall


### PR DESCRIPTION
This PR makes also this enhanced version of yadifmod2 build under linux.
Again, in my validation tests the filter outputs byte identical video stream when running native.
This version is also fair to cpu lacking support to avx instructions, thanks to the more elaborate cmake build.