### PR TITLE
Moved define into common.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -7,6 +7,13 @@
 #include <avisynth/avisynth.h>
 #endif
 
+#ifndef __GNUC__
+#define F_INLINE __forceinline
+#else
+#define F_INLINE __attribute__((always_inline)) inline
+#endif
+
+
 enum class arch_t {
     NO_SIMD,
     USE_SSE2,

--- a/src/proc_filter.cpp
+++ b/src/proc_filter.cpp
@@ -30,11 +30,6 @@
 
 #include "common.h"
 
-#ifndef __GNUC__
-#define F_INLINE __forceinline
-#else
-#define F_INLINE __attribute__((always_inline)) inline
-#endif
 
 static F_INLINE int average2(const int x, const int y) noexcept
 {

--- a/src/simd.h
+++ b/src/simd.h
@@ -28,12 +28,6 @@
 #include "common.h"
 
 
-#ifndef __GNUC__
-#define F_INLINE __forceinline
-#else
-#define F_INLINE __attribute__((always_inline)) inline
-#endif
-
 
 namespace simd {
     //-------------------SETZERO-------------------------------------------------

--- a/src/simd_avx.h
+++ b/src/simd_avx.h
@@ -32,12 +32,6 @@
 #endif
 
 
-#ifndef __GNUC__
-#define F_INLINE __forceinline
-#else
-#define F_INLINE __attribute__((always_inline)) inline
-#endif
-
 
 namespace simd {
     //-------------------------LOAD------------------------------------------------

--- a/src/simd_avx2.h
+++ b/src/simd_avx2.h
@@ -32,12 +32,6 @@
 #endif
 
 
-#ifndef __GNUC__
-#define F_INLINE __forceinline
-#else
-#define F_INLINE __attribute__((always_inline)) inline
-#endif
-
 
 namespace simd {
     //-------------------------LOAD------------------------------------------------


### PR DESCRIPTION
I moved a bunch of common '#define's into common.h, it seems cleaner to me now.